### PR TITLE
Fixed function to use given value for 'value' field.

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -341,9 +341,9 @@ def to_json_stat(input_df, value="value", output='list'):
                       for i in dims.columns.values]
         dataset = {"dataset" + str(row + 1): {"dimension": OrderedDict(),
                                               "value": list(
-                                                  dataframe['value'].where(
+                                                  dataframe[value].where(
                                                       pd.notnull(
-                                                          dataframe['value']),
+                                                          dataframe[value]),
                                                       None))}}
         for category in categories:
             dataset["dataset" + str(row + 1)]["dimension"].update(category)


### PR DESCRIPTION
Minor bugfix to the `to_json_stat` function. Previously it was always using the string 'value' to access a DataFrame column, even if a custom `value` field was passed to the function.