### PR TITLE
Fix KeyError for empty values in get_values()

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -236,6 +236,8 @@ def get_values(js_dict, value='value'):
         try:
           if values[i]:
             vals.append(values[i])
+          else:
+            vals.append(None)
         except KeyError:
             vals.append(None)
     values = vals


### PR DESCRIPTION
Pesky ONS data! Was getting a KeyError using the following dataset

URL = http://web.ons.gov.uk/ons/api/data/dataset/CPI15.json?context=Economic&jsontype=json-stat&apikey={YOUR_API_KEY}&geog=2011STATH&diff=&totals=false