### PR TITLE
Fix support for pandas < 0.17.

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -247,7 +247,7 @@ def get_dim_label(js_dict, dim, input="dataset"):
                                               dim_index.values())),
                                      index=dim_index.keys(),
                                      columns=['id', 'index'])
-    dim_label = pd.merge(dim_label, dim_index, on='id').sort_values(by='index')
+    dim_label = pd.merge(dim_label, dim_index, on='id').sort_index(by='index')
     return dim_label
 
 
@@ -280,7 +280,7 @@ def get_dim_index(js_dict, dim):
                                               dim_index.values())),
                                      index=dim_index.keys(),
                                      columns=['id', 'index'])
-    dim_index = dim_index.sort_values(by='index')
+    dim_index = dim_index.sort_index(by='index')
     return dim_index
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas==0.18.1
+pandas>=0.16.2
 requests==2.11.1


### PR DESCRIPTION
Sort_values was introduced in pandas 0.17. Sort_index is a
drop-in replacement for this use-case, but is supported in
older versions of Pandas.

This patch allows all unit tests to pass on pandas 0.16.3.