### PR TITLE
2x Performance improvement to uniquify.

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -357,13 +357,11 @@ def uniquify(seq):
       seq (list): original list.
 
     Returns:
-      list: list without duplicates preserving original order.
+      ndarray: list without duplicates preserving original order.
 
     """
-
-    seen = set()
-    seen_add = seen.add
-    return [x for x in seq if x not in seen and not seen_add(x)]
+    _, idx = np.unique(seq, return_index=True)
+    return seq[idx]
 
 
 def generate_df(js_dict, naming, value="value"):


### PR DESCRIPTION
Use np.unique instead of sets / comprehension.

   >>> data = np.random.randint(0, 100, 10000)

   # Old version:
   In [38]: %timeit _ = uniquify(data)
   1000 loops, best of 3: 1.05 ms per loop

   # New version:
   In [42]: %timeit _ = uniquify(data)
   1000 loops, best of 3: 547 µs per loop