### PR TITLE
Fix issue #20

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -611,11 +611,16 @@ class Dataset(OrderedDict):
             except ValueError:
                 raise
 
-    def write(self, output='jsonstat'):
+    def write(self, output='jsonstat', naming="label", value='value'):
         """Writes data from a Dataset object to JSONstat or Pandas Dataframe.
         Args:
             output(string): can accept 'jsonstat' or 'dataframe'. Default to
                             'jsonstat'.
+            naming (string, optional, ingored if output = 'jsonstat'): dimension naming. \
+                Possible values: 'label' or 'id'. Defaults to 'label'.
+            value (string, optional, ignored if output = 'jsonstat'): name of value column. \
+                Defaults to 'value'.
+                
 
         Returns:
             Serialized JSONstat or a Pandas Dataframe,depending on the \
@@ -626,7 +631,7 @@ class Dataset(OrderedDict):
         if output == 'jsonstat':
             return json.dumps(OrderedDict(self), cls=NumpyEncoder)
         elif output == 'dataframe':
-            return from_json_stat(self)[0]
+            return from_json_stat(self, naming=naming, value=value)[0]
         else:
             raise ValueError("Allowed arguments are 'jsonstat' or 'dataframe'")
 


### PR DESCRIPTION
In issue #20, the write method in the new Dataset class does not pass in values for naming and value to `from_json_stat` when transforming `json-stat` to `dataframe`. This leaves the user with having to use `from_json_stat` directly to allow for changing these values.