### PR TITLE
Fix #30

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -40,8 +40,8 @@ import pandas as pd
 
 import requests
 
-logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
 
 try:
     basestring

--- a/pyjstat/test/test_import.py
+++ b/pyjstat/test/test_import.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for logging import from pyjstat."""
+
+# Dependencies
+import logging
+import unittest
+
+# Class to be tested
+from pyjstat import pyjstat
+
+
+class TestPyjstat(unittest.TestCase):
+    """Unit tests for logging import from pyjstat."""
+
+    def setUp(self):
+        """
+        Set up test environment.
+
+        Remove all handlers associated with the root logger object
+        and set default log level.
+        """
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
+        logging.basicConfig(level=logging.ERROR)
+
+    def test_import(self):
+        """Check log level for root and child logger instances."""
+        self.assertEqual(
+            logging.getLogger('pyjstat.pyjstat').getEffectiveLevel(),
+            logging.INFO
+            )
+        self.assertEqual(
+            logging.getLogger().getEffectiveLevel(),
+            logging.ERROR)


### PR DESCRIPTION
Delete logging.basicConfig() line to avoid problems to
applications using the library.
Add setLevel to retain the same loglevel previously configured
inside the library.